### PR TITLE
Updated differentiate.jl to be make finite differences based on a symbolic expression

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -22,10 +22,11 @@ end
 
 # a finite difference based on a symbolic expression, given a specific x to differentiate at
 function differentiate(ex::Expr, wrt::SymbolicVariable, atx::Float64)
-    ex = differentiate(ex)
-    eval(:($wrt = $atx))
-    return eval(ex)
-end
+    ex = differentiate(ex, wrt) # symbolic only
+    local fex = :(($wrt)->($ex))
+    local f = eval(fex)
+    return f(atx)
+end      
 
 differentiate{T}(x::SymbolParameter{T}, args, wrt) = error("Derivative of function " * string(T) * " not supported")
 


### PR DESCRIPTION
Does doing this make more sense than putting it into finite_difference and having it called by derivative()?

``` Julia
julia> differentiate(:(e^x),:(x))
:(*(^(e,x),log(e)))

julia> using Calculus

julia> differentiate(:(e^x),:(x),1.0)
2.718281828459045

julia> differentiate(:(e^x),:(x),0.0)
1.0
```

Admittedly, in its current form it messes with global variables.
