### PR TITLE
changed epsilon choice in finite difference to match literature

### DIFF
--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -25,12 +25,12 @@ function finite_difference{T <: Number}(f::Function,
                                         x::T,
                                         dtype::Symbol = :central)
     if dtype == :forward
-        epsilon = sqrt(eps(max(one(T), abs(x))))
+        epsilon = sqrt(eps(T))*max(one(T),abs(x))
         xplusdx = x + epsilon
         # use machine-representable numbers
         return (f(xplusdx) - f(x)) / epsilon
     elseif dtype == :central
-        epsilon = cbrt(eps(max(one(T), abs(x))))
+        epsilon = cbrt(eps(T))*max(one(T), abs(x))
         xplusdx, xminusdx = x + epsilon, x - epsilon
         # Is it better to do 2 * epsilon or xplusdx - xminusdx?
         return (f(xplusdx) - f(xminusdx)) / (2 * epsilon)


### PR DESCRIPTION
Changes choice of epsilon in finite differencing to align with [this paper](http://www.karenkopecky.net/Teaching/eco613614/Notes_NumericalDifferentiation.pdf). 
