### PR TITLE
Add comment about dependents on the internal structure of Calculus.jl

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -113,7 +113,8 @@ function differentiate(::SymbolParameter{:/}, args, wrt)
     end
 end
 
-
+# This table is used in other packages, and if someone changes it they should notify
+# * https://github.com/scidom/DualNumbers.jl
 derivative_rules = [
     ( :sqrt,        :(  xp / 2 / sqrt(x)                         ))
     ( :cbrt,        :(  xp / 3 / cbrt(x)^2                       ))


### PR DESCRIPTION
This was my answer to https://github.com/johnmyleswhite/Calculus.jl/issues/34 before it was opened.

Other packages starts to depend on the internal structure of this package. I think it is reasonable to add a comment to tell future developers that might want to change the internal structure which public packages they will break, so that they can ping the authors. 
See: https://github.com/scidom/DualNumbers.jl/pull/1
