### PR TITLE
Enable release and nightlies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ compiler:
     - gcc
 notifications:
     email: false
+env:
+    matrix: 
+        - JULIAVERSION="juliareleases" 
+        - JULIAVERSION="julianightlies" 
 before_install:
-    - sudo apt-get update -qq -y
-    - sudo apt-get install zlib1g-dev
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
     - sudo apt-get update -qq -y
-    - sudo apt-get install patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev librmath-dev -y
-    - sudo apt-get install julia
+    - sudo apt-get install libpcre3-dev julia -y
     - git config --global user.name "Dummy Travis User"
     - git config --global user.email "travis@example.net"
 script:
-    - julia -e 'versioninfo(); Pkg.init();'
-    - mkdir -p ~/.julia/Calculus
-    - cp -R ./* ~/.julia/Calculus/
-    - julia ~/.julia/Calculus/run_tests.jl
+    - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir())/Calculus`); Pkg.resolve()'
+    - julia -e 'using Calculus; @assert isdefined(:Calculus); @assert typeof(Calculus) === Module'
+    - julia run_tests.jl


### PR DESCRIPTION
This change enables the running of travis tests with both nightly and release versions of Julia.
