### PR TITLE
Add abs2 and inv to differentiate table.  Deprecate square.

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -118,7 +118,9 @@ end
 derivative_rules = [
     ( :sqrt,        :(  xp / 2 / sqrt(x)                         ))
     ( :cbrt,        :(  xp / 3 / cbrt(x)^2                       ))
-    ( :square,      :(  xp * 2 * x                               ))
+    ( :square,      :(  xp * 2 * x                               )) # deprecated
+    ( :abs2,        :(  xp * 2 * x                               ))
+    ( :inv,         :( -xp * abs2(inv(x))                        ))
     ( :log,         :(  xp / x                                   ))
     ( :log10,       :(  xp / x / log(10)                         ))
     ( :log2,        :(  xp / x / log(2)                          ))

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -29,6 +29,9 @@
 @test isequal(differentiate(:(sin(cos(x) + sin(x))), :x), :(*(+(-sin(x),cos(x)),cos(+(cos(x),sin(x))))))
 @test isequal(differentiate(:(exp(-x)), :x), :(-exp(-x)))
 @test isequal(differentiate(:(log(x^2)), :x), :(/(*(2,x),^(x,2))))
+@test isequal(differentiate(:(square(x)), :x), :(2x)) # deprecated
+@test isequal(differentiate(:(abs2(x)), :x), :(2x))
+@test isequal(differentiate(:(inv(x)), :x), :(-abs2(inv(x))))
 @test isequal(differentiate(:(x^n), :x), :(*(n, ^(x, -(n, 1)))))
 @test isequal(differentiate(:(n^x), :x), :(*(^(n, x), log(n))))
 @test isequal(differentiate(:(n^n), :x), 0)


### PR DESCRIPTION
@scidom Apparently you should know about these changes for DualNumbers.jl  I'm not sure how the changes should be reflected in DualNumbers.jl but if you can point me in the direction I can work on a pull request for that package too.
