### PR TITLE
fix deprecation warnings and travis; drop 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
   email: false
 env:
   matrix:
-    - JULIAVERSION="juliareleases"
+#    - JULIAVERSION="juliareleases"
     - JULIAVERSION="julianightlies"
 before_install:
   - sudo add-apt-repository ppa:staticfloat/julia-deps -y

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.2-
+julia 0.3-

--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -262,7 +262,7 @@ function finite_difference_hessian!{S <: Number,
         end
         xpp[i], xpm[i], xmp[i], xmm[i] = xi, xi, xi, xi
     end
-    symmetrize!(H)
+    Base.LinAlg.copytri!(H,'U')
 end
 function finite_difference_hessian{T <: Number}(f::Function,
                                                 x::Vector{T})

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -10,8 +10,8 @@ f1(x::Real) = sin(x)
 @test norm(derivative(f1)(0.0) - cos(0.0)) < 10e-4
 
 f2(x::Vector) = sin(x[1])
-@test norm(derivative(f2, :vector, :forward)([0.0]) - cos(0.0)) < 10e-4
-@test norm(derivative(f2, :vector, :central)([0.0]) - cos(0.0)) < 10e-4
+@test norm(derivative(f2, :vector, :forward)([0.0]) .- cos(0.0)) < 10e-4
+@test norm(derivative(f2, :vector, :central)([0.0]) .- cos(0.0)) < 10e-4
 
 #
 # ctranspose overloading


### PR DESCRIPTION
No reason to support 0.2 prereleases, but we're still compatible with 0.2.
