### PR TITLE
restructure and export interface for list of symbolic derivatives

### DIFF
--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -28,8 +28,7 @@
 @test isequal(differentiate(:(sin(sin(x))), :x), :(*(cos(x),cos(sin(x)))))
 @test isequal(differentiate(:(sin(cos(x) + sin(x))), :x), :(*(+(-sin(x),cos(x)),cos(+(cos(x),sin(x))))))
 @test isequal(differentiate(:(exp(-x)), :x), :(-exp(-x)))
-@test isequal(differentiate(:(log(x^2)), :x), :(/(*(2,x),^(x,2))))
-@test isequal(differentiate(:(square(x)), :x), :(2x)) # deprecated
+@test isequal(differentiate(:(log(x^2)), :x), :((2x) * (1 / x^2)))
 @test isequal(differentiate(:(abs2(x)), :x), :(2x))
 @test isequal(differentiate(:(inv(x)), :x), :(-abs2(inv(x))))
 @test isequal(differentiate(:(x^n), :x), :(*(n, ^(x, -(n, 1)))))


### PR DESCRIPTION
Following up on the discussion in #44, here we export a standardized interface for the list of symbolic derivatives. There are no `xp` terms present. It's pretty generic, so I don't think committing to this will place much of a burden on future refactors of Calculus.jl.

The two-argument bessel functions haven't been updated. We could do with a better treatment for functions with multiple arguments, but I don't think it's an issue that needs to be solved for this PR.
