### PR TITLE
Add support to calculate analytical derivative of ifelse function

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -242,6 +242,11 @@ end
 ## hypot 
 ## beta, lbeta, eta, zeta, digamma
 
+## Differentiate for piecewise functions defined using ifelse
+function differentiate(::SymbolParameter{:ifelse}, args, wrt)
+	:(ifelse($(args[1]), $(differentiate(args[2],wrt)),$(differentiate(args[3],wrt))))
+end
+
 function differentiate(ex::Expr, targets::Vector{Symbol})
     n = length(targets)
     exprs = Array(Any, n)

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -91,3 +91,10 @@ end
 @test isequal(simplify(:(x*3)), :(*(3,x)))
 @test isequal(simplify(:(x*3*4)), :(*(12,x)))
 @test isequal(simplify(:(2*y*x*3)), :(*(6,y,x)))
+
+#
+# Tests with ifelse
+#
+@test isequal(differentiate(:(ifelse(x < 1, exp(x^2), 1/x)), :x), :(ifelse(x < 1,2x * exp(x^2), -1/x^2)))
+@test isequal(differentiate(:(ifelse(x <= 0, 0, ifelse(x > 1, 1, x))), : x), 
+														:(ifelse(x <= 0, 0, ifelse(x > 1, 0, 1))))


### PR DESCRIPTION
I have added a few lines to differentiate.jl in order to support analytical differentiation of the ifelse function which can be used to define piecewise functions. It simply returns a new ifelse function with the derivative of the second and third arguments and it also works with nested ifelse. 

It does not check whether the piecewise function is differentiable and continuous (it is up to the user to make sure that is the case).
