### PR TITLE
Slight changes for v0.3/v0.4 compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3
+Compat

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -1,4 +1,5 @@
 module Calculus
+    import Compat
     import Base.ctranspose
     export check_derivative,
            check_gradient,

--- a/src/deparse.jl
+++ b/src/deparse.jl
@@ -1,4 +1,4 @@
-const op_precedence = {:+ => 1, :- => 1, :* => 2, :/ => 2, :^ => 3}
+const op_precedence = Compat.@compat Dict(:+ => 1, :- => 1, :* => 2, :/ => 2, :^ => 3)
 
 function deparse(ex::Expr, outer_precedence=0)
     if ex.head != :call

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -40,7 +40,7 @@
 #
 
 @test isequal(differentiate(:(sin(x) + sin(y)), [:x, :y]), [:(cos(x)), :(cos(y))])
-@test isequal(differentiate(:(x^2), [:x, :y]), {:(2*x), 0})
+@test isequal(differentiate(:(x^2), [:x, :y]), Any[:(2*x), 0])
 
 # TODO: Get the generalized power rule right.
 # @test isequal(differentiate(:(sin(x)^2), :x), :(2 * sin(x) * cos(x)))


### PR DESCRIPTION
A few slight tweaks so I don't get warning messages when I run import Calculus on v0.4. Adds Compat as a requirement, but hopefully that's not an issue.
