### PR TITLE
specified the derivative of the digamma function

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -166,6 +166,7 @@ symbolic_derivative_1arg_list = [
     ( :erfi,        :(  2 * exp(square(x)) / sqrt(pi)           ))
     ( :gamma,       :(  digamma(x) * gamma(x)                   ))
     ( :lgamma,      :(  digamma(x)                              ))
+    ( :digamma,     :(  polygamma(1, x)                         ))
     ( :airy,        :(  airyprime(x)                            ))  # note: only covers the 1-arg version
     ( :airyprime,   :(  airy(2, x)                              ))
     ( :airyai,      :(  airyaiprime(x)                          ))


### PR DESCRIPTION
I added the derivative of `digamma` to `differentiate.jl`. I needed this rule for reasoning about the second derivative of `lgamma`...figured others might want to use this differentiation rule too. 

CC @rgiordan