### PR TITLE
Extend Base.gradient instead of defining a new one on 0.4

### DIFF
--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -14,6 +14,8 @@ module Calculus
            jacobian,
            second_derivative
 
+    import Base: gradient
+
     # TODO: Debate type system more carefully
     # abstract BundledFunction
     # abstract ScalarFunction


### PR DESCRIPTION
Not sure if this is the best long term solution but at least it makes all tests pass and IMHO produce the least breakage for users.
