### PR TITLE
Fix deprecation warning and other extra white space

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -1,4 +1,3 @@
-
 export differentiate
 
 #################################################################
@@ -6,7 +5,7 @@ export differentiate
 # differentiate()
 #   based on John's differentiate and this code, I think by Miles Lubin:
 #     https://github.com/IainNZ/NLTester/blob/master/julia/nlp.jl#L74
-#   
+#
 #################################################################
 
 differentiate(ex::SymbolicVariable, wrt::SymbolicVariable) = (ex == wrt) ? 1 : 0
@@ -33,7 +32,7 @@ function differentiate(::SymbolParameter{:^}, args, wrt)
     elseif yp == 0
         return :( $y * $xp * ($x ^ ($y - 1)) )
     else
-        return :( $x ^ $y * ($xp * $y / $x + $yp * log($x)) ) 
+        return :( $x ^ $y * ($xp * $y / $x + $yp * log($x)) )
     end
 end
 
@@ -215,12 +214,12 @@ for (funsym, exp) in symbolic_derivative_1arg_list
 end
 
 derivative_rules_bessel = [
-    ( :besselj,    :(   * (besselj(nu - 1, x) - besselj(nu + 1, x)) / 2   ))
-    ( :besseli,    :(   * (besseli(nu - 1, x) + besseli(nu + 1, x)) / 2   ))
-    ( :bessely,    :(   * (bessely(nu - 1, x) - bessely(nu + 1, x)) / 2   ))
+    ( :besselj,    :(    (besselj(nu - 1, x) - besselj(nu + 1, x)) / 2   ))
+    ( :besseli,    :(    (besseli(nu - 1, x) + besseli(nu + 1, x)) / 2   ))
+    ( :bessely,    :(    (bessely(nu - 1, x) - bessely(nu + 1, x)) / 2   ))
     ( :besselk,    :( -1 * (besselk(nu - 1, x) + besselk(nu + 1, x)) / 2   ))
-    ( :hankelh1,   :(   * (hankelh1(nu - 1, x) - hankelh1(nu + 1, x)) / 2 ))
-    ( :hankelh2,   :(   * (hankelh2(nu - 1, x) - hankelh2(nu + 1, x)) / 2 ))
+    ( :hankelh1,   :(    (hankelh1(nu - 1, x) - hankelh1(nu + 1, x)) / 2 ))
+    ( :hankelh2,   :(    (hankelh2(nu - 1, x) - hankelh2(nu + 1, x)) / 2 ))
 ]
 
 
@@ -258,7 +257,7 @@ end
 
 ## Differentiate for piecewise functions defined using ifelse
 function differentiate(::SymbolParameter{:ifelse}, args, wrt)
-	:(ifelse($(args[1]), $(differentiate(args[2],wrt)),$(differentiate(args[3],wrt))))
+    :(ifelse($(args[1]), $(differentiate(args[2],wrt)),$(differentiate(args[3],wrt))))
 end
 
 function differentiate(ex::Expr, targets::Vector{Symbol})


### PR DESCRIPTION
Please correct me if I'm wrong but I think the extra `*` should not be necessary.