### PR TITLE
Fix nonboolean `all` deprecation warning.

### DIFF
--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -93,7 +93,7 @@ function simplify(ex::Expr)
     if ex.head != :call
         return ex
     end
-    if all(map(isnumber, ex.args[2:end])) && length(ex.args) > 1
+    if all(isnumber, ex.args[2:end]) && length(ex.args) > 1
         return eval(ex)
     end
     new_ex = simplify(SymbolParameter(ex.args[1]), ex.args[2:end])


### PR DESCRIPTION
In `any`/`all`, using maps and comprehensions that cannot be guaranteed to return an array of booleans was recently deprecated. This also allows `all` to short circuit once a `false` is found.