### PR TITLE
deprecate extension of Base.gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Most users will want to work with a limited set of basic functions:
 
 * `derivative()`: Use this for functions from R to R
 * `second_derivative()`: Use this for functions from R to R
-* `gradient()`: Use this for functions from R^n to R
+* `Calculus.gradient()`: Use this for functions from R^n to R
 * `hessian()`: Use this for functions from R^n to R
 * `differentiate()`: Use this to perform symbolic differentiation
 * `simplify()`: Use this to perform symbolic simplification
@@ -42,14 +42,14 @@ There are a few basic approaches to using the Calculus package:
 	# Compare with cos(1.0)
 	derivative(sin, 1.0)
 	# Compare with cos(pi)
-	derivative(sin, float64(pi))
+	derivative(sin, float(pi))
 
 	# Compare with [cos(0.0), -sin(0.0)]
-	gradient(x -> sin(x[1]) + cos(x[2]), [0.0, 0.0])
+	Calculus.gradient(x -> sin(x[1]) + cos(x[2]), [0.0, 0.0])
 	# Compare with [cos(1.0), -sin(1.0)]
-	gradient(x -> sin(x[1]) + cos(x[2]), [1.0, 1.0])
+	Calculus.gradient(x -> sin(x[1]) + cos(x[2]), [1.0, 1.0])
 	# Compare with [cos(pi), -sin(pi)]
-	gradient(x -> sin(x[1]) + cos(x[2]), [float64(pi), float64(pi)])
+	Calculus.gradient(x -> sin(x[1]) + cos(x[2]), [float64(pi), float64(pi)])
 
 	# Compare with -sin(0.0)
 	second_derivative(sin, 0.0)
@@ -74,7 +74,7 @@ There are a few basic approaches to using the Calculus package:
 	g1(1.0)
 	g1(pi)
 
-	g2 = gradient(x -> sin(x[1]) + cos(x[2]))
+	g2 = Calculus.gradient(x -> sin(x[1]) + cos(x[2]))
 	g2([0.0, 0.0])
 	g2([1.0, 1.0])
 	g2([pi, pi])

--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -10,12 +10,9 @@ module Calculus
            deparse,
            derivative,
            differentiate,
-           gradient,
            hessian,
            jacobian,
            second_derivative
-
-    import Base: gradient
 
     # TODO: Debate type system more carefully
     # abstract BundledFunction

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -14,6 +14,16 @@ derivative(f::Function, dtype::Symbol = :central) = derivative(f, :scalar, dtype
 Compat.@compat gradient{T <: Number}(f::Function, x::Union{T, Vector{T}}, dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
 gradient(f::Function, dtype::Symbol = :central) = derivative(f, :vector, dtype)
 
+Compat.@compat function Base.gradient{T <: Number}(f::Function, x::Union{T, Vector{T}}, dtype::Symbol = :central)
+    Base.warn_once("The finite difference methods from Calculus.jl no longer extend Base.gradient and should be called as Calculus.gradient instead. This usage is deprecated.")
+    Calculus.gradient(f,x,dtype)
+end
+
+function Base.gradient(f::Function, dtype::Symbol = :central)
+    Base.warn_once("The finite difference methods from Calculus.jl no longer extend Base.gradient and should be called as Calculus.gradient instead. This usage is deprecated.")
+    Calculus.gradient(f,dtype)
+end
+
 ctranspose(f::Function) = derivative(f)
 
 function jacobian{T <: Number}(f::Function, x::Vector{T}, dtype::Symbol)

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -27,9 +27,9 @@ end
 #
 
 f4(x::Vector) = (100.0 - x[1])^2 + (50.0 - x[2])^2
-@test norm(gradient(f4, :forward)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
-@test norm(gradient(f4, :central)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
-@test norm(gradient(f4)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+@test norm(Calculus.gradient(f4, :forward)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+@test norm(Calculus.gradient(f4, :central)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
+@test norm(Calculus.gradient(f4)([100.0, 50.0]) - [0.0, 0.0]) < 10e-4
 
 #
 # second_derivative()
@@ -45,5 +45,5 @@ f4(x::Vector) = (100.0 - x[1])^2 + (50.0 - x[2])^2
 #
 
 f5(x) = sin(x[1]) + cos(x[2])
-@test norm(gradient(f5)([0.0, 0.0]) - [cos(0.0), -sin(0.0)]) < 10e-4
+@test norm(Calculus.gradient(f5)([0.0, 0.0]) - [cos(0.0), -sin(0.0)]) < 10e-4
 @test norm(hessian(f5)([0.0, 0.0]) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4

--- a/test/finite_difference.jl
+++ b/test/finite_difference.jl
@@ -47,7 +47,7 @@
 #
 
 fx(x) = sin(x[1]) + cos(x[2])
-gx = gradient(fx)
+gx = Calculus.gradient(fx)
 @test norm(gx([0.0, 0.0]) - [cos(0.0), -sin(0.0)]) < 10e-4
 @test norm(Calculus.finite_difference_hessian(fx, gx, [0.0, 0.0], :central) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4
 @test norm(Calculus.finite_difference_hessian(fx, [0.0, 0.0]) - [-sin(0.0) 0.0; 0.0 -cos(0.0)]) < 10e-4


### PR DESCRIPTION
This export is a common source of confusion for users of ForwardDiff, e.g. https://github.com/JuliaDiff/ForwardDiff.jl/issues/70. I don't think Calculus has a claim to extend Base's method any more so than ForwardDiff, so the least confusing solution is for neither to extend the method.

CC @jrevels 