### PR TITLE
fix UndefVar errors on Julia v0.5

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -1,12 +1,11 @@
 function derivative(f::Function, ftype::Symbol, dtype::Symbol)
   if ftype == :scalar
-    g(x::Number) = finite_difference(f, float(x), dtype)
+    return x::Number -> finite_difference(f, float(x), dtype)
   elseif ftype == :vector
-    g(x::Vector) = finite_difference(f, float(x), dtype)
+    return x::Vector -> finite_difference(f, float(x), dtype)
   else
     error("ftype must :scalar or :vector")
   end
-  return g
 end
 Compat.@compat derivative{T <: Number}(f::Function, x::Union{T, Vector{T}}, dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
 derivative(f::Function, dtype::Symbol = :central) = derivative(f, :scalar, dtype)
@@ -37,13 +36,12 @@ jacobian(f::Function) = jacobian(f, :central)
 
 function second_derivative(f::Function, g::Function, ftype::Symbol, dtype::Symbol)
   if ftype == :scalar
-    h(x::Number) = finite_difference_hessian(f, g, x, dtype)
+    return x::Number -> finite_difference_hessian(f, g, x, dtype)
   elseif ftype == :vector
-    h(x::Vector) = finite_difference_hessian(f, g, x, dtype)
+    return x::Vector -> finite_difference_hessian(f, g, x, dtype)
   else
     error("ftype must :scalar or :vector")
   end
-  return h
 end
 Compat.@compat function second_derivative{T <: Number}(f::Function, g::Function, x::Union{T, Vector{T}}, dtype::Symbol)
   finite_difference_hessian(f, g, x, dtype)


### PR DESCRIPTION
This fixes the following error:

```julia
julia> import Calculus

julia> Calculus.hessian(sum, [1,2,3])
ERROR: UndefVarError: g not defined
 in derivative(::Function, ::Symbol, ::Symbol) at /Users/jarrettrevels/.julia/v0.5/Calculus/src/derivative.jl:9
 in hessian(::Function, ::Array{Int64,1}) at /Users/jarrettrevels/.julia/v0.5/Calculus/src/derivative.jl:82
 in eval(::Module, ::Any) at ./boot.jl:225
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
```

@mlubin If you could tag a new version of Calculus after this is merged, that would allow tests to pass in JuliaDiff/ForwardDiff.jl#102
