### PR TITLE
Uncomment derivatives of erfcx and dawson

### DIFF
--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -182,8 +182,8 @@ symbolic_derivative_1arg_list = [
     ( :besselj1,    :(  (besselj0(x) - besselj(2, x)) / 2       ))
     ( :bessely0,    :( -bessely1(x)                             ))
     ( :bessely1,    :(  (bessely0(x) - bessely(2, x)) / 2       ))
-    ## ( :erfcx,   :(  (2 * x * erfcx(x) - 2 / sqrt(pi))   ))  # uncertain
-    ## ( :dawson,  :(  (1 - 2x * dawson(x))                ))  # uncertain
+    ( :erfcx,       :(  (2 * x * erfcx(x) - 2 / sqrt(pi))       ))
+    ( :dawson,      :(  (1 - 2x * dawson(x))                    ))
 
 ]
 


### PR DESCRIPTION
Following-up PR #93, here I uncomment a couple of derivatives that were hidden in the code. They're are correct.  The derivative of Dawson function is reported at http://mathworld.wolfram.com/DawsonsIntegral.html.  The derivative of `erfcx` can be worked out using the product rule.