### PR TITLE
update deprecated Array constructor for Julia v0.6 (drops v0.3 support)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia:
-    - 0.3
     - 0.4
     - 0.5
     - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3.7
+julia 0.4
 Compat 0.4.0

--- a/src/differentiate.jl
+++ b/src/differentiate.jl
@@ -79,9 +79,9 @@ end
 # d/dx (f * g * h) = (d/dx f) * g * h + f * (d/dx g) * h + ...
 function differentiate(::SymbolParameter{:*}, args, wrt)
     n = length(args)
-    res_args = Array(Any, n)
+    res_args = Vector{Any}(n)
     for i in 1:n
-       new_args = Array(Any, n)
+       new_args = Vector{Any}(n)
        for j in 1:n
            if j == i
                new_args[j] = differentiate(args[j], wrt)
@@ -200,7 +200,7 @@ export symbolic_derivatives_1arg
 
 # deprecated: for backward compatibility with packages that used
 # this unexported interface.
-derivative_rules = Array(@Compat.compat(Tuple{Symbol,Expr}),0)
+derivative_rules = Vector{Compat.@compat(Tuple{Symbol,Expr})}(0)
 for (s,ex) in symbolic_derivative_1arg_list
     push!(derivative_rules, (s, :(xp*$ex)))
 end
@@ -267,7 +267,7 @@ end
 
 function differentiate(ex::Expr, targets::Vector{Symbol})
     n = length(targets)
-    exprs = Array(Any, n)
+    exprs = Vector{Any}(n)
     for i in 1:n
         exprs[i] = differentiate(ex, targets[i])
     end

--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -139,7 +139,7 @@ function finite_difference{T <: Number}(f::Function,
                                         x::Vector{T},
                                         dtype::Symbol = :central)
     # Allocate memory for gradient
-    g = Array(Float64, length(x))
+    g = Vector{Float64}(length(x))
 
     # Mutate allocated gradient
     finite_difference!(f, float(x), g, dtype)
@@ -270,7 +270,7 @@ function finite_difference_hessian{T <: Number}(f::Function,
     n = length(x)
 
     # Allocate an empty Hessian
-    H = Array(Float64, n, n)
+    H = Matrix{Float64}(n, n)
 
     # Mutate the allocated Hessian
     finite_difference_hessian!(f, x, H)


### PR DESCRIPTION
Calculus technically supports Julia v0.3 in its REQUIRE file, and I'm not sure this fix will work on v0.3. Could you use `Vector{T}(n)` and `Matrix{T}(n, m)` back then? I guess Travis should tell us...