### PR TITLE
Resolving issue #61: Expressions evaluated to NaN

### DIFF
--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -96,7 +96,7 @@ function simplify(ex::Expr)
         return eval(current_module(), ex)
     end
     new_ex = simplify(SymbolParameter(ex.args[1]), ex.args[2:end])
-    while new_ex != ex
+    while !(isequal(new_ex, ex))
         new_ex, ex = simplify(new_ex), new_ex
     end
     return new_ex

--- a/test/symbolic.jl
+++ b/test/symbolic.jl
@@ -92,6 +92,8 @@ end
 @test isequal(simplify(:(x*3*4)), :(*(12,x)))
 @test isequal(simplify(:(2*y*x*3)), :(*(6,y,x)))
 
+@test isequal(simplify(:(sin((1*(sin(0/0)))))), NaN)
+
 #
 # Tests with ifelse
 #


### PR DESCRIPTION
Changed `!=` to use `!isequal()` to not get stuck in infinite loops with NaN.
Non-trivial test also added that verifies this.