### PR TITLE
Remove unnecessary function typing

### DIFF
--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -26,28 +26,28 @@ module Calculus
 
     # const NonDifferentiableFunction = Function
     # type DifferentiableFunction
-    #   f::Function
-    #   g::Function
+    #   f
+    #   g
     # end
     # type TwiceDifferentiableFunction
-    #   f::Function
-    #   g::Function
-    #   h::Function
+    #   f
+    #   g
+    #   h
     # end
     # type NonDifferentiableBundledFunction <: BundledFunction
-    #   f::Function
+    #   f
     #   fstorage::Any
     # end
     # type DifferentiableBundledFunction <: BundledFunction
-    #   f::Function
-    #   g::Function
+    #   f
+    #   g
     #   fstorage::Any
     #   gstorage::Any
     # end
     # type TwiceDifferentiableBundledFunction <: BundledFunction
-    #   f::Function
-    #   g::Function
-    #   h::Function
+    #   f
+    #   g
+    #   h
     #   fstorage::Any
     #   gstorage::Any
     #   hstorage::Any

--- a/src/check_derivative.jl
+++ b/src/check_derivative.jl
@@ -1,19 +1,19 @@
-Compat.@compat function check_derivative(f::Function, g::Function, x::Number)
+Compat.@compat function check_derivative(f, g, x::Number)
     auto_g = derivative(f)
     return maximum(abs.(g(x) - auto_g(x)))
 end
 
-Compat.@compat function check_gradient{T <: Number}(f::Function, g::Function, x::Vector{T})
+Compat.@compat function check_gradient{T <: Number}(f, g, x::Vector{T})
     auto_g = gradient(f)
     return maximum(abs.(g(x) - auto_g(x)))
 end
 
-Compat.@compat function check_second_derivative(f::Function, h::Function, x::Number)
+Compat.@compat function check_second_derivative(f, h, x::Number)
     auto_h = second_derivative(f)
     return maximum(abs.(h(x) - auto_h(x)))
 end
 
-Compat.@compat function check_hessian{T <: Number}(f::Function, h::Function, x::Vector{T})
+Compat.@compat function check_hessian{T <: Number}(f, h, x::Vector{T})
     auto_h = hessian(f)
     return maximum(abs.(h(x) - auto_h(x)))
 end

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -1,4 +1,4 @@
-function derivative(f::Function, ftype::Symbol, dtype::Symbol)
+function derivative(f, ftype::Symbol, dtype::Symbol)
   if ftype == :scalar
     return x::Number -> finite_difference(f, float(x), dtype)
   elseif ftype == :vector
@@ -7,34 +7,34 @@ function derivative(f::Function, ftype::Symbol, dtype::Symbol)
     error("ftype must :scalar or :vector")
   end
 end
-Compat.@compat derivative{T <: Number}(f::Function, x::Union{T, Vector{T}}, dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
-derivative(f::Function, dtype::Symbol = :central) = derivative(f, :scalar, dtype)
+Compat.@compat derivative{T <: Number}(f, x::Union{T, Vector{T}}, dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
+derivative(f, dtype::Symbol = :central) = derivative(f, :scalar, dtype)
 
-Compat.@compat gradient{T <: Number}(f::Function, x::Union{T, Vector{T}}, dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
-gradient(f::Function, dtype::Symbol = :central) = derivative(f, :vector, dtype)
+Compat.@compat gradient{T <: Number}(f, x::Union{T, Vector{T}}, dtype::Symbol = :central) = finite_difference(f, float(x), dtype)
+gradient(f, dtype::Symbol = :central) = derivative(f, :vector, dtype)
 
-Compat.@compat function Base.gradient{T <: Number}(f::Function, x::Union{T, Vector{T}}, dtype::Symbol = :central)
+Compat.@compat function Base.gradient{T <: Number}(f, x::Union{T, Vector{T}}, dtype::Symbol = :central)
     Base.warn_once("The finite difference methods from Calculus.jl no longer extend Base.gradient and should be called as Calculus.gradient instead. This usage is deprecated.")
     Calculus.gradient(f,x,dtype)
 end
 
-function Base.gradient(f::Function, dtype::Symbol = :central)
+function Base.gradient(f, dtype::Symbol = :central)
     Base.warn_once("The finite difference methods from Calculus.jl no longer extend Base.gradient and should be called as Calculus.gradient instead. This usage is deprecated.")
     Calculus.gradient(f,dtype)
 end
 
 ctranspose(f::Function) = derivative(f)
 
-function jacobian{T <: Number}(f::Function, x::Vector{T}, dtype::Symbol)
+function jacobian{T <: Number}(f, x::Vector{T}, dtype::Symbol)
     finite_difference_jacobian(f, x, dtype)
 end
-function jacobian(f::Function, dtype::Symbol)
+function jacobian(f, dtype::Symbol)
     g(x::Vector) = finite_difference_jacobian(f, x, dtype)
     return g
 end
-jacobian(f::Function) = jacobian(f, :central)
+jacobian(f) = jacobian(f, :central)
 
-function second_derivative(f::Function, g::Function, ftype::Symbol, dtype::Symbol)
+function second_derivative(f, g, ftype::Symbol, dtype::Symbol)
   if ftype == :scalar
     return x::Number -> finite_difference_hessian(f, g, x, dtype)
   elseif ftype == :vector
@@ -43,45 +43,45 @@ function second_derivative(f::Function, g::Function, ftype::Symbol, dtype::Symbo
     error("ftype must :scalar or :vector")
   end
 end
-Compat.@compat function second_derivative{T <: Number}(f::Function, g::Function, x::Union{T, Vector{T}}, dtype::Symbol)
+Compat.@compat function second_derivative{T <: Number}(f, g, x::Union{T, Vector{T}}, dtype::Symbol)
   finite_difference_hessian(f, g, x, dtype)
 end
-Compat.@compat function hessian{T <: Number}(f::Function, g::Function, x::Union{T, Vector{T}}, dtype::Symbol)
+Compat.@compat function hessian{T <: Number}(f, g, x::Union{T, Vector{T}}, dtype::Symbol)
   finite_difference_hessian(f, g, x, dtype)
 end
-Compat.@compat function second_derivative{T <: Number}(f::Function, g::Function, x::Union{T, Vector{T}})
+Compat.@compat function second_derivative{T <: Number}(f, g, x::Union{T, Vector{T}})
   finite_difference_hessian(f, g, x, :central)
 end
-Compat.@compat function hessian{T <: Number}(f::Function, g::Function, x::Union{T, Vector{T}})
+Compat.@compat function hessian{T <: Number}(f, g, x::Union{T, Vector{T}})
   finite_difference_hessian(f, g, x, :central)
 end
-function second_derivative(f::Function, x::Number, dtype::Symbol)
+function second_derivative(f, x::Number, dtype::Symbol)
   finite_difference_hessian(f, derivative(f), x, dtype)
 end
-function hessian(f::Function, x::Number, dtype::Symbol)
+function hessian(f, x::Number, dtype::Symbol)
   finite_difference_hessian(f, derivative(f), x, dtype)
 end
-function second_derivative{T <: Number}(f::Function, x::Vector{T}, dtype::Symbol)
+function second_derivative{T <: Number}(f, x::Vector{T}, dtype::Symbol)
   finite_difference_hessian(f, gradient(f), x, dtype)
 end
-function hessian{T <: Number}(f::Function, x::Vector{T}, dtype::Symbol)
+function hessian{T <: Number}(f, x::Vector{T}, dtype::Symbol)
   finite_difference_hessian(f, gradient(f), x, dtype)
 end
-function second_derivative(f::Function, x::Number)
+function second_derivative(f, x::Number)
   finite_difference_hessian(f, derivative(f), x, :central)
 end
-function hessian(f::Function, x::Number)
+function hessian(f, x::Number)
   finite_difference_hessian(f, derivative(f), x, :central)
 end
-function second_derivative{T <: Number}(f::Function, x::Vector{T})
+function second_derivative{T <: Number}(f, x::Vector{T})
   finite_difference_hessian(f, gradient(f), x, :central)
 end
-function hessian{T <: Number}(f::Function, x::Vector{T})
+function hessian{T <: Number}(f, x::Vector{T})
   finite_difference_hessian(f, gradient(f), x, :central)
 end
-second_derivative(f::Function, g::Function, dtype::Symbol) = second_derivative(f, g, :scalar, dtype)
-second_derivative(f::Function, g::Function) = second_derivative(f, g, :scalar, :central)
-second_derivative(f::Function) = second_derivative(f, derivative(f), :scalar, :central)
-hessian(f::Function, g::Function, dtype::Symbol) = second_derivative(f, g, :vector, dtype)
-hessian(f::Function, g::Function) = second_derivative(f, g, :vector, :central)
-hessian(f::Function) = second_derivative(f, gradient(f), :vector, :central)
+second_derivative(f, g, dtype::Symbol) = second_derivative(f, g, :scalar, dtype)
+second_derivative(f, g) = second_derivative(f, g, :scalar, :central)
+second_derivative(f) = second_derivative(f, derivative(f), :scalar, :central)
+hessian(f, g, dtype::Symbol) = second_derivative(f, g, :vector, dtype)
+hessian(f, g) = second_derivative(f, g, :vector, :central)
+hessian(f) = second_derivative(f, gradient(f), :vector, :central)

--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -42,7 +42,7 @@ macro complexrule(x, e)
     end
 end
 
-function finite_difference{T <: Number}(f::Function,
+function finite_difference{T <: Number}(f,
                                         x::T,
                                         dtype::Symbol = :central)
     if dtype == :forward
@@ -97,7 +97,7 @@ end
 ##
 ##############################################################################
 
-function finite_difference!{S <: Number, T <: Number}(f::Function,
+function finite_difference!{S <: Number, T <: Number}(f,
                                                       x::Vector{S},
                                                       g::Vector{T},
                                                       dtype::Symbol)
@@ -135,7 +135,7 @@ function finite_difference!{S <: Number, T <: Number}(f::Function,
 
     return
 end
-function finite_difference{T <: Number}(f::Function,
+function finite_difference{T <: Number}(f,
                                         x::Vector{T},
                                         dtype::Symbol = :central)
     # Allocate memory for gradient
@@ -156,7 +156,7 @@ end
 
 function finite_difference_jacobian!{R <: Number,
                                      S <: Number,
-                                     T <: Number}(f::Function,
+                                     T <: Number}(f,
                                                   x::Vector{R},
                                                   f_x::Vector{S},
                                                   J::Array{T},
@@ -190,7 +190,7 @@ function finite_difference_jacobian!{R <: Number,
 
     return
 end
-function finite_difference_jacobian{T <: Number}(f::Function,
+function finite_difference_jacobian{T <: Number}(f,
                                                  x::Vector{T},
                                                  dtype::Symbol = :central)
     # Establish a baseline for f_x
@@ -212,13 +212,13 @@ end
 ##
 ##############################################################################
 
-function finite_difference_hessian{T <: Number}(f::Function,
+function finite_difference_hessian{T <: Number}(f,
                                                 x::T)
     @hessianrule x epsilon
     (f(x + epsilon) - 2*f(x) + f(x - epsilon))/epsilon^2
 end
-function finite_difference_hessian(f::Function,
-                                   g::Function,
+function finite_difference_hessian(f,
+                                   g,
                                    x::Number,
                                    dtype::Symbol = :central)
     finite_difference(g, x, dtype)
@@ -231,7 +231,7 @@ end
 ##############################################################################
 
 function finite_difference_hessian!{S <: Number,
-                                    T <: Number}(f::Function,
+                                    T <: Number}(f,
                                                  x::Vector{S},
                                                  H::Array{T})
     # What is the dimension of x?
@@ -263,7 +263,7 @@ function finite_difference_hessian!{S <: Number,
     end
     Base.LinAlg.copytri!(H,'U')
 end
-function finite_difference_hessian{T <: Number}(f::Function,
+function finite_difference_hessian{T <: Number}(f,
                                                 x::Vector{T})
     # What is the dimension of x?
     n = length(x)
@@ -277,8 +277,8 @@ function finite_difference_hessian{T <: Number}(f::Function,
     # Return the Hessian
     return H
 end
-function finite_difference_hessian{T <: Number}(f::Function,
-                                                g::Function,
+function finite_difference_hessian{T <: Number}(f,
+                                                g,
                                                 x::Vector{T},
                                                 dtype::Symbol = :central)
     finite_difference_jacobian(g, x, dtype)
@@ -294,7 +294,7 @@ end
 
 # Higher precise finite difference method based on Taylor series approximation.
 # h is the stepsize
-function taylor_finite_difference(f::Function,
+function taylor_finite_difference(f,
                                   x::Real,
                                   dtype::Symbol = :central,
                                   h::Real = 10e-4)
@@ -313,7 +313,7 @@ function taylor_finite_difference(f::Function,
     return d
 end
 
-function taylor_finite_difference_hessian(f::Function,
+function taylor_finite_difference_hessian(f,
                                           x::Real,
                                           h::Real)
     f_x = f(x)
@@ -330,15 +330,15 @@ end
 
 # The function "dirderivative" calculates directional derivatives in the direction v.
 # The function supplied must have the form Vector{Float64} -> Float64
-# function dirderivative(f::Function, v::Vector{Float64}, x0::Vector{Float64}, h::Float64, twoside::Bool)
+# function dirderivative(f, v::Vector{Float64}, x0::Vector{Float64}, h::Float64, twoside::Bool)
 #     derivative(t::Float64 -> f(x0 + v*t) / norm(v), 0.0, h, twoside)
 # end
-# function dirderivative(f::Function, v::Vector{Float64}, x0::Vector{Float64}, h::Float64)
+# function dirderivative(f, v::Vector{Float64}, x0::Vector{Float64}, h::Float64)
 #     dirderivative(f, v, x0, h, true)
 # end
-# function dirderivative(f::Function, v::Vector{Float64}, x0::Vector{Float64}, )
+# function dirderivative(f, v::Vector{Float64}, x0::Vector{Float64}, )
 #     derivative(f, v, x0, 0.0001)
 # end
-# function dirderivative(f::Function, v::Vector{Float64})
+# function dirderivative(f, v::Vector{Float64})
 #     x -> dirderivative(f, v, x)
 # end


### PR DESCRIPTION
All of the functions have `::Function` which doesn't help performance but makes it so that many functions can't be differentiated. This PR gets rid of those extra type-assertions to make this package have wider applicability.