### PR TITLE
Fix allocate memory Vector bug

### DIFF
--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -139,7 +139,7 @@ function finite_difference{T <: Number}(f,
                                         x::AbstractVector{T},
                                         dtype::Symbol = :central)
     # Allocate memory for gradient
-    g = AbstractVector{Float64}(length(x))
+    g = Vector{Float64}(length(x))
 
     # Mutate allocated gradient
     finite_difference!(f, float(x), g, dtype)


### PR DESCRIPTION
AbstractVector{Float64}(length(x))   tries to  `convert` an object of type Int64 to an object of type AbstractArray{Float64,1}