### PR TITLE
Fix most of depwarns and errors on 0.7

### DIFF
--- a/src/Calculus.jl
+++ b/src/Calculus.jl
@@ -2,7 +2,6 @@ isdefined(Base, :__precompile__) && __precompile__()
 
 module Calculus
     import Compat
-    import Base.ctranspose
     export check_derivative,
            check_gradient,
            check_hessian,

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -23,7 +23,11 @@ function Base.gradient(f, dtype::Symbol = :central)
     Calculus.gradient(f,dtype)
 end
 
-ctranspose(f::Function) = derivative(f)
+if isdefined(Base, :adjoint)
+    Base.adjoint(f::Function) = derivative(f)
+else
+    Base.ctranspose(f::Function) = derivative(f)
+end
 
 function jacobian{T <: Number}(f, x::Vector{T}, dtype::Symbol)
     finite_difference_jacobian(f, x, dtype)

--- a/test/derivative.jl
+++ b/test/derivative.jl
@@ -14,7 +14,7 @@ f2(x::Vector) = sin(x[1])
 @test norm(derivative(f2, :vector, :central)([0.0]) .- cos(0.0)) < 10e-4
 
 #
-# ctranspose overloading
+# adjoint overloading
 #
 
 f3(x::Real) = sin(x)


### PR DESCRIPTION
* The adjoint overloading is a serious type piracy
* The `current_module()` depwarn is not fixed since fixing it requires
  threading the module over all functions in an API visible way.