### PR TITLE
handle irrational constants by casting to float

### DIFF
--- a/src/finite_difference.jl
+++ b/src/finite_difference.jl
@@ -45,6 +45,10 @@ end
 function finite_difference(f,
                            x::T,
                            dtype::Symbol = :central) where T <: Number
+    # handle irrationals
+    if T <: Irrational
+        x = float(x)
+    end
     if dtype == :forward
         @forwardrule x epsilon
         xplusdx = x + epsilon
@@ -101,6 +105,10 @@ function finite_difference!(f,
                             x::AbstractVector{S},
                             g::AbstractVector{T},
                             dtype::Symbol) where {S <: Number, T <: Number}
+    # handle irrationals
+    if S <: Irrational
+        x = float.(x)
+    end
     # What is the dimension of x?
     n = length(x)
 
@@ -161,6 +169,10 @@ function finite_difference_jacobian!(f,
                                      dtype::Symbol = :central) where {R <: Number,
                                                                     S <: Number,
                                                                     T <: Number}
+    # handle irrationals
+    if R <: Irrational
+        x = float.(x)
+    end
     # What is the dimension of x?
     m, n = size(J)
 
@@ -214,6 +226,10 @@ end
 
 function finite_difference_hessian(f,
                                    x::T) where T <: Number
+    # handle irrationals
+    if typeof(x) <: Irrational
+        x = float(x)
+    end
     @hessianrule x epsilon
     (f(x + epsilon) - 2*f(x) + f(x - epsilon))/epsilon^2
 end
@@ -234,6 +250,10 @@ function finite_difference_hessian!(f,
                                     x::AbstractVector{S},
                                     H::Array{T}) where {S <: Number,
                                                         T <: Number}
+    # handle irrationals
+    if S <: Irrational
+        x = float.(x)
+    end
     # What is the dimension of x?
     n = length(x)
 

--- a/test/finite_difference.jl
+++ b/test/finite_difference.jl
@@ -9,6 +9,7 @@
 @test norm(Calculus.finite_difference(x -> sin(x), 1.0, :forward) - cos(1.0)) < 10e-4
 @test norm(Calculus.finite_difference(x -> sin(x), 1.0, :central) - cos(1.0)) < 10e-4
 @test norm(Calculus.finite_difference(x -> sin(x), 1.0) - cos(1.0)) < 10e-4
+@test norm(Calculus.finite_difference(x -> sin(x), pi) + 1) < 10e-4
 
 @test norm(Calculus.finite_difference(x -> exp(-x), 1.0, :forward) - (-exp(-1.0))) < 10e-4
 @test norm(Calculus.finite_difference(x -> exp(-x), 1.0, :central) - (-exp(-1.0))) < 10e-4
@@ -21,6 +22,7 @@
 @test norm(Calculus.finite_difference(x -> x[1]^2, [1.0], :forward) - [2.0]) < 10e-4
 @test norm(Calculus.finite_difference(x -> x[1]^2, [1.0], :central) - [2.0]) < 10e-4
 @test norm(Calculus.finite_difference(x -> x[1]^2, [1.0]) - [2.0]) < 10e-4
+@test norm(Calculus.finite_difference(x -> x[1]^2, [float(pi)]) - [2*pi]) < 10e-4
 
 @test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0], :forward) - [cos(1.0)]) < 10e-4
 @test norm(Calculus.finite_difference(x -> sin(x[1]), [1.0], :central) - [cos(1.0)]) < 10e-4


### PR DESCRIPTION
eps(n) and thus finite_difference(<>,n) and its friends fail for n of irrational type. It's certainly an edge case, but we can do a quick conversion to float for these (pi, catalan, etc)

closes #144